### PR TITLE
Implement vpcMatch with vmMatch match criteria for Azure.

### DIFF
--- a/apis/crd/v1alpha1/cloudentityselector_types.go
+++ b/apis/crd/v1alpha1/cloudentityselector_types.go
@@ -28,7 +28,7 @@ type EntityMatch struct {
 }
 
 // VirtualMachineSelector specifies VirtualMachine match criteria.
-// VirtualMachines must satisfy all fields(ANDed) in VirtualMachineSelector in order to satisfy match.
+// VirtualMachines must satisfy all fields(ANDed) in a VirtualMachineSelector in order to satisfy match.
 type VirtualMachineSelector struct {
 	// VpcMatch specifies the virtual private cloud to which VirtualMachines belong.
 	// VpcMatch is ANDed with VMMatch.
@@ -45,10 +45,9 @@ type CloudEntitySelectorSpec struct {
 	// AccountName specifies cloud account in this CloudProvider.
 	AccountName string `json:"accountName,omitempty"`
 	// VMSelector selects the VirtualMachines the user has modify privilege.
-	// If VMSelector is not specified, no VirtualMachines are selected.
+	// VMSelector is mandatory, at least one selector under VMSelector is required.
 	// It is an array, VirtualMachines satisfying any item on VMSelector are selected(ORed).
-	// If any item under VMSelector is not specified, all VirtualMachines are selected.
-	VMSelector []VirtualMachineSelector `json:"vmSelector,omitempty"`
+	VMSelector []VirtualMachineSelector `json:"vmSelector"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/crd.cloud.antrea.io_cloudentityselectors.yaml
+++ b/config/crd/bases/crd.cloud.antrea.io_cloudentityselectors.yaml
@@ -43,14 +43,13 @@ spec:
                 type: string
               vmSelector:
                 description: VMSelector selects the VirtualMachines the user has modify
-                  privilege. If VMSelector is not specified, no VirtualMachines are
-                  selected. It is an array, VirtualMachines satisfying any item on
-                  VMSelector are selected(ORed). If any item under VMSelector is not
-                  specified, all VirtualMachines are selected.
+                  privilege. VMSelector is mandatory, at least one selector under
+                  VMSelector is required. It is an array, VirtualMachines satisfying
+                  any item on VMSelector are selected(ORed).
                 items:
                   description: VirtualMachineSelector specifies VirtualMachine match
-                    criteria. VirtualMachines must satisfy all fields(ANDed) in VirtualMachineSelector
-                    in order to satisfy match.
+                    criteria. VirtualMachines must satisfy all fields(ANDed) in a
+                    VirtualMachineSelector in order to satisfy match.
                   properties:
                     vmMatch:
                       description: VMMatch specifies VirtualMachines to match. It
@@ -89,6 +88,8 @@ spec:
                       type: object
                   type: object
                 type: array
+            required:
+            - vmSelector
             type: object
         type: object
     served: true

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -49,9 +49,9 @@ spec:
                 description: AccountName specifies cloud account in this CloudProvider.
                 type: string
               vmSelector:
-                description: VMSelector selects the VirtualMachines the user has modify privilege. If VMSelector is not specified, no VirtualMachines are selected. It is an array, VirtualMachines satisfying any item on VMSelector are selected(ORed). If any item under VMSelector is not specified, all VirtualMachines are selected.
+                description: VMSelector selects the VirtualMachines the user has modify privilege. VMSelector is mandatory, at least one selector under VMSelector is required. It is an array, VirtualMachines satisfying any item on VMSelector are selected(ORed).
                 items:
-                  description: VirtualMachineSelector specifies VirtualMachine match criteria. VirtualMachines must satisfy all fields(ANDed) in VirtualMachineSelector in order to satisfy match.
+                  description: VirtualMachineSelector specifies VirtualMachine match criteria. VirtualMachines must satisfy all fields(ANDed) in a VirtualMachineSelector in order to satisfy match.
                   properties:
                     vmMatch:
                       description: VMMatch specifies VirtualMachines to match. It is an array, match satisfying any item on VMMatch is selected(ORed). If it is not specified, all VirtualMachines matching VpcMatch are selected.
@@ -78,6 +78,8 @@ spec:
                       type: object
                   type: object
                 type: array
+            required:
+            - vmSelector
             type: object
         type: object
     served: true

--- a/config/samples/cloud_v1alpha1_cloudentityselector.yaml
+++ b/config/samples/cloud_v1alpha1_cloudentityselector.yaml
@@ -1,3 +1,4 @@
+# Match based on vpcMatch:  All vms in vpc <VPC_ID> are matched
 apiVersion: crd.cloud.antrea.io/v1alpha1
 kind: CloudEntitySelector
 metadata:
@@ -8,3 +9,17 @@ spec:
   vmSelector:
       - vpcMatch:
           matchID: "<VPC_ID>"
+---
+# Match based on vmMatch in the vpc configured : A vm with id <VM_ID> in vpc <VPC_ID> is matched
+apiVersion: crd.cloud.antrea.io/v1alpha1
+kind: CloudEntitySelector
+metadata:
+  name: cloudentityselector-sample01
+  namespace: sample-ns
+spec:
+  accountName: cloudprovideraccount-sample
+  vmSelector:
+    - vpcMatch:
+        matchID: "<VPC_ID>"
+      vmMatch:
+        - matchID: "<VM_ID>"

--- a/config/samples/cloud_v1alpha1_virtualmachine.yaml
+++ b/config/samples/cloud_v1alpha1_virtualmachine.yaml
@@ -1,4 +1,0 @@
-apiVersion: crd.cloud.antrea.io/v1alpha1
-kind: VirtualMachine
-metadata:
-  name: virtualmachine-sample

--- a/config/samples/cloudaccount_aws.yaml
+++ b/config/samples/cloudaccount_aws.yaml
@@ -19,6 +19,5 @@ metadata:
 spec:
   accountName: cloudprovideraccount-sample
   vmSelector:
-    vmMatches:
-      - vpcMatch:
-          matchID: "<VPC_ID>"
+    - vpcMatch:
+        matchID: "<VPC_ID>"

--- a/config/samples/cloudaccount_azure.yaml
+++ b/config/samples/cloudaccount_azure.yaml
@@ -20,6 +20,5 @@ metadata:
 spec:
   accountName: cloudprovideraccount-sample
   vmSelector:
-    vmMatches:
-      - vpcMatch:
-          matchID: "<VNET_ID>"
+    - vpcMatch:
+        matchID: "<VNET_ID>"

--- a/pkg/cloud-provider/cloudapi/azure/azure_resourcegraph.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_resourcegraph.go
@@ -28,6 +28,7 @@ const (
 	vnetIDsNotFoundErrorMsg         = "vnet ID(s) required for the query"
 	vmIDsNotFoundErrorMsg           = "vm ID(s) required for the query"
 	vmNamesNotFoundErrorMsg         = "vm names(s) required for the query"
+	vmIDorNameNotFoundErrorMsg      = "vm id or name is required for the query"
 )
 
 // resourceGraph returns resource-graph SDK apiClient.

--- a/pkg/cloud-provider/cloudapi/azure/azure_resourcegraph_vmTable.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_resourcegraph_vmTable.go
@@ -128,7 +128,7 @@ func getVirtualMachineTable(resourceGraphAPIClient azureResourceGraphWrapper, qu
 	return virtualMachines, count, nil
 }
 
-func getVMsByVnetIDsAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vnetIDs []string, subscriptionIDs []string, tenantIDs []string,
+func getVMsByVnetIDsMatchQuery(vnetIDs []string, subscriptionIDs []string, tenantIDs []string,
 	locations []string) (*string, error) {
 	commaSeparatedVnetIDs := convertStrSliceToLowercaseCommaSeparatedStr(vnetIDs)
 	if len(commaSeparatedVnetIDs) == 0 {
@@ -164,7 +164,7 @@ func getVMsByVnetIDsAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vnetIDs
 	return queryString, nil
 }
 
-func getVMsByVMNamesAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vmNames []string, subscriptionIDs []string, tenantIDs []string,
+func getVMsByVMNamesMatchQuery(vmNames []string, subscriptionIDs []string, tenantIDs []string,
 	locations []string) (*string, error) {
 	commaSeparatedVMNames := convertStrSliceToLowercaseCommaSeparatedStr(vmNames)
 	if len(commaSeparatedVMNames) == 0 {
@@ -200,7 +200,7 @@ func getVMsByVMNamesAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vmNames
 	return queryString, nil
 }
 
-func getVMsByVMIDsAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vmIDs []string, subscriptionIDs []string, tenantIDs []string,
+func getVMsByVMIDsMatchQuery(vmIDs []string, subscriptionIDs []string, tenantIDs []string,
 	locations []string) (*string, error) {
 	commaSeparatedVMIDs := convertStrSliceToLowercaseCommaSeparatedStr(vmIDs)
 	if len(commaSeparatedVMIDs) == 0 {
@@ -260,6 +260,61 @@ func getVMsBySubscriptionIDsAndTenantIDsAndLocationsMatchQuery(subscriptionIDs [
 	}
 
 	queryString, err := buildVmsTableQueryWithParams("getVMsBySubscriptionIDsAndTenantIDsAndLocationsMatchQuery", queryParams)
+	if err != nil {
+		return nil, err
+	}
+	return queryString, nil
+}
+
+func getVMsByVnetAndOtherMatchesQuery(vnetIDs []string, vmNames []string, vmIDs []string, subscriptionIDs []string,
+	tenantIDs []string, locations []string) (*string, error) {
+	var queryParams *vmTableQueryParameters
+	commaSeparatedSubscriptionIDs := convertStrSliceToLowercaseCommaSeparatedStr(subscriptionIDs)
+	if len(commaSeparatedSubscriptionIDs) == 0 {
+		return nil, fmt.Errorf(subscriptionIDsNotFoundErrorMsg)
+	}
+
+	commaSeparatedTenantIDs := convertStrSliceToLowercaseCommaSeparatedStr(tenantIDs)
+	if len(commaSeparatedTenantIDs) == 0 {
+		return nil, fmt.Errorf(tenantIDsNotFoundErrorMsg)
+	}
+
+	commaSeparatedLocations := convertStrSliceToLowercaseCommaSeparatedStr(locations)
+	if len(commaSeparatedLocations) == 0 {
+		return nil, fmt.Errorf(locationsNotFoundErrorMsg)
+	}
+
+	commaSeparatedVnetIDs := convertStrSliceToLowercaseCommaSeparatedStr(vnetIDs)
+	if len(commaSeparatedVnetIDs) == 0 {
+		return nil, fmt.Errorf(vnetIDsNotFoundErrorMsg)
+	}
+
+	commaSeparatedVMIDs := convertStrSliceToLowercaseCommaSeparatedStr(vmIDs)
+
+	commaSeparatedVMNames := convertStrSliceToLowercaseCommaSeparatedStr(vmNames)
+
+	if len(commaSeparatedVMIDs) == 0 && len(commaSeparatedVMNames) == 0 {
+		return nil, fmt.Errorf(vmIDorNameNotFoundErrorMsg)
+	}
+	if len(commaSeparatedVMNames) == 0 {
+		queryParams = &vmTableQueryParameters{
+			SubscriptionIDs: &commaSeparatedSubscriptionIDs,
+			TenantIDs:       &commaSeparatedTenantIDs,
+			Locations:       &commaSeparatedLocations,
+			VMIDs:           &commaSeparatedVMIDs,
+			VnetIDs:         &commaSeparatedVnetIDs,
+		}
+	} else {
+		queryParams = &vmTableQueryParameters{
+			SubscriptionIDs: &commaSeparatedSubscriptionIDs,
+			TenantIDs:       &commaSeparatedTenantIDs,
+			Locations:       &commaSeparatedLocations,
+			VMNames:         &commaSeparatedVMNames,
+			VnetIDs:         &commaSeparatedVnetIDs,
+		}
+	}
+
+	queryString, err := buildVmsTableQueryWithParams("getVMsByVMIDsAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery", queryParams)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud-provider/cloudapi/azure/azure_test.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Azure", func() {
 			It("Should match expected filter - single vpcID only match", func() {
 				vnetIDs = []string{testVnetID01}
 				var expectedQueryStrs []*string
-				expectedQueryStr, _ := getVMsByVnetIDsAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vnetIDs,
+				expectedQueryStr, _ := getVMsByVnetIDsMatchQuery(vnetIDs,
 					subIDs, tenantIDs, locations)
 				expectedQueryStrs = append(expectedQueryStrs, expectedQueryStr)
 				vmSelector := []v1alpha1.VirtualMachineSelector{
@@ -163,7 +163,7 @@ var _ = Describe("Azure", func() {
 		It("Should match expected filter with credential - multiple vpcID only match", func() {
 			vnetIDs = []string{testVnetID01, testVnetID02}
 			var expectedQueryStrs []*string
-			expectedQueryStr, _ := getVMsByVnetIDsAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vnetIDs,
+			expectedQueryStr, _ := getVMsByVnetIDsMatchQuery(vnetIDs,
 				subIDs, tenantIDs, locations)
 			expectedQueryStrs = append(expectedQueryStrs, expectedQueryStr)
 			vmSelector := []v1alpha1.VirtualMachineSelector{
@@ -192,7 +192,7 @@ var _ = Describe("Azure", func() {
 		It("Should match expected filter with identity client id - multiple vpcID only match", func() {
 			vnetIDs = []string{testVnetID01, testVnetID02}
 			var expectedQueryStrs []*string
-			expectedQueryStr, _ := getVMsByVnetIDsAndSubscriptionIDsAndTenantIDsAndLocationsMatchQuery(vnetIDs,
+			expectedQueryStr, _ := getVMsByVnetIDsMatchQuery(vnetIDs,
 				subIDs, tenantIDs, locations)
 			expectedQueryStrs = append(expectedQueryStrs, expectedQueryStr)
 			vmSelector := []v1alpha1.VirtualMachineSelector{

--- a/test/integration/crd_rw_test.go
+++ b/test/integration/crd_rw_test.go
@@ -54,6 +54,13 @@ var _ = Describe(fmt.Sprintf("%s,%s: Basic CRD Read-Write", focusAws, focusAzure
 			},
 			Spec: v1alpha1.CloudEntitySelectorSpec{
 				AccountName: testAccountName,
+				VMSelector: []v1alpha1.VirtualMachineSelector{
+					{
+						VpcMatch: &v1alpha1.EntityMatch{
+							MatchID: "",
+						},
+					},
+				},
 			},
 		}
 	)


### PR DESCRIPTION
- Vpc id match with vm id or vm name is implemented for Azure
- Added validation at webhook level to block if matchID and
  matchName are configured in an EntityMatch.
- Updated CES sample yamls.
- Removed VM, EE CRD sample yamls.
- Blocking at webhook level if vmSelector is not configured with
  atleast one selector.
- Making vmSelector a madatory field.
- Added CES webhook check for unsupported match combinations.