### PR TITLE
Webhook changes for CloudProviderAccount CRD.

### DIFF
--- a/apis/crd/v1alpha1/cloudprovideraccount_webhook.go
+++ b/apis/crd/v1alpha1/cloudprovideraccount_webhook.go
@@ -81,11 +81,11 @@ func (r *CloudProviderAccount) ValidateCreate() error {
 
 	switch cloudProviderType {
 	case AWSCloudProvider:
-		if err := r.ValidateAWSAccount(); err != nil {
+		if err := r.validateAWSAccount(); err != nil {
 			return err
 		}
 	case AzureCloudProvider:
-		if err := r.ValidateAzureAccount(); err != nil {
+		if err := r.validateAzureAccount(); err != nil {
 			return err
 		}
 	}
@@ -108,11 +108,11 @@ func (r *CloudProviderAccount) ValidateUpdate(old runtime.Object) error {
 
 	switch cloudProviderType {
 	case AWSCloudProvider:
-		if err := r.ValidateAWSAccount(); err != nil {
+		if err := r.validateAWSAccount(); err != nil {
 			return err
 		}
 	case AzureCloudProvider:
-		if err := r.ValidateAzureAccount(); err != nil {
+		if err := r.validateAzureAccount(); err != nil {
 			return err
 		}
 	}
@@ -142,7 +142,7 @@ func (r *CloudProviderAccount) GetAccountProviderType() (CloudProvider, error) {
 	}
 }
 
-func (r *CloudProviderAccount) ValidateAWSAccount() error {
+func (r *CloudProviderAccount) validateAWSAccount() error {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "",
@@ -194,7 +194,7 @@ func (r *CloudProviderAccount) ValidateAWSAccount() error {
 	return nil
 }
 
-func (r *CloudProviderAccount) ValidateAzureAccount() error {
+func (r *CloudProviderAccount) validateAzureAccount() error {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "",

--- a/apis/crd/v1alpha1/cloudprovideraccount_webhook.go
+++ b/apis/crd/v1alpha1/cloudprovideraccount_webhook.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"k8s.io/apimachinery/pkg/types"
 	"strings"
 
@@ -36,6 +37,8 @@ var (
 	cloudprovideraccountlog = logf.Log.WithName("cloudprovideraccount-resource")
 	clientK8s               k8sclient.Client
 )
+
+const MinPollInterval = 30
 
 func (r *CloudProviderAccount) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	clientK8s = mgr.GetClient()
@@ -63,7 +66,7 @@ func (r *CloudProviderAccount) Default() {
 
 // TODO(user): change verbs to :"verbs=create;update;delete" if you want to enable deletion validation.
 // nolint:lll
-// +kubebuilder:webhook:verbs=create,path=/validate-crd-cloud-antrea-io-v1alpha1-cloudprovideraccount,mutating=false,failurePolicy=fail,groups=crd.cloud.antrea.io,resources=cloudprovideraccounts,versions=v1alpha1,name=vcloudprovideraccount.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-crd-cloud-antrea-io-v1alpha1-cloudprovideraccount,mutating=false,failurePolicy=fail,groups=crd.cloud.antrea.io,resources=cloudprovideraccounts,versions=v1alpha1,name=vcloudprovideraccount.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ webhook.Validator = &CloudProviderAccount{}
 
@@ -75,82 +78,19 @@ func (r *CloudProviderAccount) ValidateCreate() error {
 	if err != nil {
 		return err
 	}
-	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "",
-		Kind:    "Secret",
-		Version: "v1",
-	})
 
 	switch cloudProviderType {
 	case AWSCloudProvider:
-		awsConfig := r.Spec.AWSConfig
-		err := clientK8s.Get(context.TODO(), types.NamespacedName{
-			Namespace: awsConfig.SecretRef.Namespace,
-			Name:      awsConfig.SecretRef.Name}, u)
-		if err != nil {
-			return fmt.Errorf("unable to get secret: %s", err.Error())
-		}
-		data := u.Object["data"].(map[string]interface{})
-		decode, err := base64.StdEncoding.DecodeString(data[awsConfig.SecretRef.Key].(string))
-		if err != nil {
-			return fmt.Errorf("unable to decode the secret: %s", err.Error())
-		}
-
-		awsCredential := &AwsAccountCredential{}
-		if err = json.Unmarshal(decode, awsCredential); err != nil {
-			return fmt.Errorf("unable to unmarshal the json: %s", err.Error())
-		}
-		// validate roleArn or A
-		if len(strings.TrimSpace(awsCredential.RoleArn)) != 0 {
-			cloudprovideraccountlog.Info("Role ARN configured will be used for cloud-account access")
-		} else if len(strings.TrimSpace(awsCredential.AccessKeyID)) == 0 || len(strings.TrimSpace(awsCredential.AccessKeySecret)) == 0 {
-			return fmt.Errorf("must specify either credentials or role arn, cannot both be empty")
-		}
-
-		if len(strings.TrimSpace(awsConfig.Region)) == 0 {
-			return fmt.Errorf("region cannot be blank or empty")
+		if err := r.ValidateAWSAccount(); err != nil {
+			return err
 		}
 	case AzureCloudProvider:
-		azureConfig := r.Spec.AzureConfig
-
-		err := clientK8s.Get(context.TODO(), types.NamespacedName{
-			Namespace: azureConfig.SecretRef.Namespace,
-			Name:      azureConfig.SecretRef.Name}, u)
-		if err != nil {
-			return fmt.Errorf("unable to get secret: %s", err.Error())
-		}
-		data := u.Object["data"].(map[string]interface{})
-		decode, err := base64.StdEncoding.DecodeString(data[azureConfig.SecretRef.Key].(string))
-		if err != nil {
-			return fmt.Errorf("unable to decode the secret: %s", err.Error())
-		}
-
-		azureCredential := &AzureAccountCredential{}
-		if err = json.Unmarshal(decode, azureCredential); err != nil {
-			return fmt.Errorf("unable to unmarshal the json: %s", err.Error())
-		}
-
-		// validate subscription ID
-		if len(strings.TrimSpace(azureCredential.SubscriptionID)) == 0 {
-			return fmt.Errorf("subscription id cannot be blank or empty")
-		}
-		// validate tenant ID
-		if len(strings.TrimSpace(azureCredential.TenantID)) == 0 {
-			return fmt.Errorf("tenant id cannot be blank or empty")
-		}
-		// validate credentials
-		if len(strings.TrimSpace(azureCredential.ClientID)) == 0 || len(strings.TrimSpace(azureCredential.ClientKey)) == 0 {
-			return fmt.Errorf("must specify either credentials or managed identity client id, cannot both be empty")
-		}
-
-		// validate region
-		if len(strings.TrimSpace(azureConfig.Region)) == 0 {
-			return fmt.Errorf("region cannot be blank or empty")
+		if err := r.ValidateAzureAccount(); err != nil {
+			return err
 		}
 	}
 
-	if *r.Spec.PollIntervalInSeconds < 30 {
+	if *r.Spec.PollIntervalInSeconds < MinPollInterval {
 		return fmt.Errorf("pollIntervalInSeconds should be >= 30. If not specified, defaults to 60")
 	}
 
@@ -161,7 +101,26 @@ func (r *CloudProviderAccount) ValidateCreate() error {
 func (r *CloudProviderAccount) ValidateUpdate(old runtime.Object) error {
 	cloudprovideraccountlog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	cloudProviderType, err := r.GetAccountProviderType()
+	if err != nil {
+		return err
+	}
+
+	switch cloudProviderType {
+	case AWSCloudProvider:
+		if err := r.ValidateAWSAccount(); err != nil {
+			return err
+		}
+	case AzureCloudProvider:
+		if err := r.ValidateAzureAccount(); err != nil {
+			return err
+		}
+	}
+
+	if *r.Spec.PollIntervalInSeconds < MinPollInterval {
+		return fmt.Errorf("pollIntervalInSeconds should be >= 30. If not specified, defaults to 60")
+	}
+
 	return nil
 }
 
@@ -181,4 +140,104 @@ func (r *CloudProviderAccount) GetAccountProviderType() (CloudProvider, error) {
 	} else {
 		return "", fmt.Errorf("missing cloud provider config. Please add AWS or Azure Config")
 	}
+}
+
+func (r *CloudProviderAccount) ValidateAWSAccount() error {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "",
+		Kind:    "Secret",
+		Version: "v1",
+	})
+
+	awsConfig := r.Spec.AWSConfig
+
+	err := clientK8s.Get(context.TODO(), types.NamespacedName{
+		Namespace: awsConfig.SecretRef.Namespace,
+		Name:      awsConfig.SecretRef.Name}, u)
+	if err != nil {
+		return fmt.Errorf("unable to get secret: %s", err.Error())
+	}
+	data := u.Object["data"].(map[string]interface{})
+	decode, err := base64.StdEncoding.DecodeString(data[awsConfig.SecretRef.Key].(string))
+	if err != nil {
+		return fmt.Errorf("unable to decode the secret: %s", err.Error())
+	}
+
+	awsCredential := &AwsAccountCredential{}
+	if err = json.Unmarshal(decode, awsCredential); err != nil {
+		return fmt.Errorf("unable to unmarshal the json: %s", err.Error())
+	}
+	// validate roleArn or A
+	if len(strings.TrimSpace(awsCredential.RoleArn)) != 0 {
+		cloudprovideraccountlog.Info("Role ARN configured will be used for cloud-account access")
+	} else if len(strings.TrimSpace(awsCredential.AccessKeyID)) == 0 || len(strings.TrimSpace(awsCredential.AccessKeySecret)) == 0 {
+		return fmt.Errorf("must specify either credentials or role arn, cannot both be empty")
+	}
+
+	if len(strings.TrimSpace(awsConfig.Region)) == 0 {
+		return fmt.Errorf("region cannot be blank or empty")
+	}
+
+	// NOTE: currently only AWS standard partition regions supported (aws-cn, aws-us-gov etc are not
+	// supported). As we add support for other partitions, validation needs to be updated
+	regions := endpoints.AwsPartition().Regions()
+	_, found := regions[awsConfig.Region]
+	if !found {
+		var supportedRegions []string
+		for key := range regions {
+			supportedRegions = append(supportedRegions, key)
+		}
+		return fmt.Errorf("%v not in supported regions [%v]", awsConfig.Region, supportedRegions)
+	}
+
+	return nil
+}
+
+func (r *CloudProviderAccount) ValidateAzureAccount() error {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "",
+		Kind:    "Secret",
+		Version: "v1",
+	})
+
+	azureConfig := r.Spec.AzureConfig
+
+	err := clientK8s.Get(context.TODO(), types.NamespacedName{
+		Namespace: azureConfig.SecretRef.Namespace,
+		Name:      azureConfig.SecretRef.Name}, u)
+	if err != nil {
+		return fmt.Errorf("unable to get secret: %s", err.Error())
+	}
+	data := u.Object["data"].(map[string]interface{})
+	decode, err := base64.StdEncoding.DecodeString(data[azureConfig.SecretRef.Key].(string))
+	if err != nil {
+		return fmt.Errorf("unable to decode the secret: %s", err.Error())
+	}
+
+	azureCredential := &AzureAccountCredential{}
+	if err = json.Unmarshal(decode, azureCredential); err != nil {
+		return fmt.Errorf("unable to unmarshal the json: %s", err.Error())
+	}
+
+	// validate subscription ID
+	if len(strings.TrimSpace(azureCredential.SubscriptionID)) == 0 {
+		return fmt.Errorf("subscription id cannot be blank or empty")
+	}
+	// validate tenant ID
+	if len(strings.TrimSpace(azureCredential.TenantID)) == 0 {
+		return fmt.Errorf("tenant id cannot be blank or empty")
+	}
+	// validate credentials
+	if len(strings.TrimSpace(azureCredential.ClientID)) == 0 || len(strings.TrimSpace(azureCredential.ClientKey)) == 0 {
+		return fmt.Errorf("must specify either credentials or managed identity client id, cannot both be empty")
+	}
+
+	// validate region
+	if len(strings.TrimSpace(azureConfig.Region)) == 0 {
+		return fmt.Errorf("region cannot be blank or empty")
+	}
+
+	return nil
 }

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -853,6 +853,7 @@ webhooks:
     - v1alpha1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - cloudprovideraccounts
   sideEffects: None

--- a/config/webhook/manifests-new.yaml
+++ b/config/webhook/manifests-new.yaml
@@ -126,6 +126,7 @@ webhooks:
           - v1alpha1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - cloudprovideraccounts
     sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -112,6 +112,7 @@ webhooks:
     - v1alpha1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - cloudprovideraccounts
   sideEffects: None

--- a/pkg/cloud-provider/cloudapi/aws/aws_account_mgmt.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_account_mgmt.go
@@ -26,7 +26,6 @@ import (
 
 	"antrea.io/nephe/apis/crd/v1alpha1"
 	"antrea.io/nephe/pkg/cloud-provider/cloudapi/internal"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 )
 
 type awsAccountConfig struct {
@@ -45,18 +44,6 @@ func setAccountCredentials(client client.Client, credentials interface{}) (inter
 	awsConfig := &awsAccountConfig{
 		AwsAccountCredential: *accCred,
 		region:               strings.TrimSpace(awsProviderConfig.Region),
-	}
-
-	// NOTE: currently only AWS standard partition regions supported (aws-cn, aws-us-gov etc are not
-	// supported). As we add support for other partitions, validation needs to be updated
-	regions := endpoints.AwsPartition().Regions()
-	_, found := regions[awsConfig.region]
-	if !found {
-		var supportedRegions []string
-		for key := range regions {
-			supportedRegions = append(supportedRegions, key)
-		}
-		return nil, fmt.Errorf("%v not in supported regions [%v]", awsConfig.region, supportedRegions)
 	}
 
 	return awsConfig, nil

--- a/pkg/cloud-provider/cloudapi/aws/aws_test.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_test.go
@@ -92,21 +92,6 @@ var _ = Describe("AWS cloud", func() {
 		AfterEach(func() {
 			mockCtrl.Finish()
 		})
-
-		Context("New account add fail scenarios", func() {
-			It("Should fail for unsupported/unknown region", func() {
-				account.Spec.AWSConfig.Region = "invalid"
-				_ = fakeClient.Create(context.Background(), secret)
-				c := newAWSCloud(mockawsCloudHelper)
-				err := c.AddProviderAccount(fakeClient, account)
-
-				Expect(err).ShouldNot(BeNil())
-				accCfg, found := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-				Expect(found).To(BeFalse())
-				Expect(accCfg).To(BeNil())
-			})
-		})
-
 		Context("New account add success scenarios", func() {
 			var (
 				selector *v1alpha1.CloudEntitySelector


### PR DESCRIPTION
- Moved CPA region name validation to webhook.
- Enabled webhook for CRD update operation.
- Copied validations present in CPA webhook create to webhook update too.